### PR TITLE
Fix Fedex::RateError problem

### DIFF
--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'httparty',            '>= 0.8.3'
+  s.add_dependency 'httparty',            '>= 0.14.0'
   s.add_dependency 'nokogiri',            '>= 1.5.6'
 
   s.add_development_dependency "rspec",   '~> 3.0.0'

--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -372,7 +372,7 @@ module Fedex
 
       # Parse response, convert keys to underscore symbols
       def parse_response(response)
-        response = sanitize_response_keys(response)
+        response = sanitize_response_keys(response.parsed_response)
       end
 
       # Recursively sanitizes the response object by cleaning up any hash keys.


### PR DESCRIPTION
The new `httparty` added another layer of wrapping around the `response`, but calling `response.parsed_response` will return the same data as before.

EDIT: Hmmm....this has some failing specs. Will look into it further.
